### PR TITLE
Various fixes and improvements

### DIFF
--- a/src/gw2al_api.rs
+++ b/src/gw2al_api.rs
@@ -4,22 +4,6 @@
 
 use std::os::raw::c_void;
 
-pub const GW2AL_CORE_FUNN_HASH_NAME: gw2al_hashed_name = 1;
-pub const GW2AL_CORE_FUNN_REG_FUN: gw2al_hashed_name = 2;
-pub const GW2AL_CORE_FUNN_UNREG_FUN: gw2al_hashed_name = 3;
-pub const GW2AL_CORE_FUNN_QUERY_FUN: gw2al_hashed_name = 4;
-pub const GW2AL_CORE_FUNN_FILL_VTBL: gw2al_hashed_name = 5;
-pub const GW2AL_CORE_FUNN_UNLOAD_ADDON: gw2al_hashed_name = 6;
-pub const GW2AL_CORE_FUNN_LOAD_ADDON: gw2al_hashed_name = 7;
-pub const GW2AL_CORE_FUNN_QUERY_ADDON: gw2al_hashed_name = 8;
-pub const GW2AL_CORE_FUNN_WATCH_EVENT: gw2al_hashed_name = 9;
-pub const GW2AL_CORE_FUNN_UNWATCH_EVENT: gw2al_hashed_name = 10;
-pub const GW2AL_CORE_FUNN_QUERY_EVENT: gw2al_hashed_name = 11;
-pub const GW2AL_CORE_FUNN_TRIGGER_EVENT: gw2al_hashed_name = 12;
-pub const GW2AL_CORE_FUNN_CLIENT_UNLOAD: gw2al_hashed_name = 13;
-pub const GW2AL_CORE_FUNN_LOG_TEXT: gw2al_hashed_name = 14;
-pub const GW2AL_CORE_FUNN_D3DCREATE_HOOK: gw2al_hashed_name = 15;
-
 pub const EMPTY_ADDON_DSC: gw2al_addon_dsc = gw2al_addon_dsc {
     name: std::ptr::null(),
     description: std::ptr::null(),
@@ -86,26 +70,28 @@ pub type gw2al_event_id = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct gw2al_core_vtable {
-    pub hash_name: unsafe extern "C" fn(name: *mut u16) -> u64,
+    pub hash_name: unsafe extern "C" fn(name: *mut u16) -> gw2al_hashed_name,
+    pub register_function:
+        unsafe extern "C" fn(function: *mut c_void, name: gw2al_hashed_name) -> gw2al_api_ret,
     pub unregister_function: unsafe extern "C" fn(name: gw2al_hashed_name),
     pub query_function: unsafe extern "C" fn(name: gw2al_hashed_name) -> *mut c_void,
+    pub fill_vtable:
+        unsafe extern "C" fn(nameList: *mut gw2al_hashed_name, vtable: *mut *mut c_void),
     pub unload_addon: unsafe extern "C" fn(name: gw2al_hashed_name) -> gw2al_api_ret,
     pub load_addon: unsafe extern "C" fn(name: *mut u16) -> gw2al_api_ret,
     pub query_addon: unsafe extern "C" fn(name: gw2al_hashed_name) -> *mut gw2al_addon_dsc,
-    pub query_event: unsafe extern "C" fn(name: gw2al_hashed_name) -> gw2al_event_id,
-    pub trigger_event: unsafe extern "C" fn(id: gw2al_event_id, data: *mut c_void) -> u32,
-    pub client_unload: unsafe extern "C" fn(),
-    pub fill_vtable:
-        unsafe extern "C" fn(nameList: *mut gw2al_hashed_name, vtable: *mut *mut c_void),
-    pub unwatch_event: unsafe extern "C" fn(id: gw2al_event_id, subscriber: gw2al_hashed_name),
     pub watch_event: unsafe extern "C" fn(
         id: gw2al_event_id,
         subscriber: gw2al_hashed_name,
         handler: gw2al_api_event_handler,
         priority: u32,
     ) -> gw2al_api_ret,
-    pub register_function:
-        unsafe extern "C" fn(function: *mut c_void, name: gw2al_hashed_name) -> gw2al_api_ret,
+    pub unwatch_event: unsafe extern "C" fn(id: gw2al_event_id, subscriber: gw2al_hashed_name),
+    pub query_event: unsafe extern "C" fn(name: gw2al_hashed_name) -> gw2al_event_id,
+    pub trigger_event: unsafe extern "C" fn(id: gw2al_event_id, data: *mut c_void) -> u32,
+    pub client_unload: unsafe extern "C" fn(),
+    pub log_text_sync:
+        unsafe extern "C" fn(level: gw2al_log_level, source: *mut u16, text: *mut u16),
     pub log_text: unsafe extern "C" fn(level: gw2al_log_level, source: *mut u16, text: *mut u16),
 }
 

--- a/src/gw2al_api.rs
+++ b/src/gw2al_api.rs
@@ -21,23 +21,23 @@ pub const GW2AL_CORE_FUNN_LOG_TEXT: gw2al_hashed_name = 14;
 pub const GW2AL_CORE_FUNN_D3DCREATE_HOOK: gw2al_hashed_name = 15;
 
 pub const EMPTY_ADDON_DSC: gw2al_addon_dsc = gw2al_addon_dsc {
-    name:        std::ptr::null(),
+    name: std::ptr::null(),
     description: std::ptr::null(),
-    majorVer:    0,
-    minorVer:    0,
-    revision:    0,
-    dependList:  std::ptr::null_mut(),
+    majorVer: 0,
+    minorVer: 0,
+    revision: 0,
+    dependList: std::ptr::null_mut(),
 };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct gw2al_addon_dsc {
-    pub name:        *const u16,
+    pub name: *const u16,
     pub description: *const u16,
-    pub majorVer:    u8,
-    pub minorVer:    u8,
-    pub revision:    u32,
-    pub dependList:  *mut gw2al_addon_dsc,
+    pub majorVer: u8,
+    pub minorVer: u8,
+    pub revision: u32,
+    pub dependList: *mut gw2al_addon_dsc,
 }
 
 unsafe impl Send for gw2al_addon_dsc {}
@@ -46,13 +46,13 @@ unsafe impl Sync for gw2al_addon_dsc {}
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum gw2al_api_ret {
-    OK               = 0,
-    FAIL             = 1,
-    IN_USE           = 2,
-    NOT_FOUND        = 3,
-    BAD_DLL          = 4,
-    DEP_NOT_LOADED   = 5,
-    DEP_OUTDATED     = 6,
+    OK = 0,
+    FAIL = 1,
+    IN_USE = 2,
+    NOT_FOUND = 3,
+    BAD_DLL = 4,
+    DEP_NOT_LOADED = 5,
+    DEP_OUTDATED = 6,
     DEP_STILL_LOADED = 7,
     STATIC_LIMIT_HIT = 8,
 }
@@ -60,9 +60,9 @@ pub enum gw2al_api_ret {
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum gw2al_log_level {
-    INFO  = 0,
-    ERR   = 1,
-    WARN  = 2,
+    INFO = 0,
+    ERR = 1,
+    WARN = 2,
     DEBUG = 3,
 }
 
@@ -86,15 +86,15 @@ pub type gw2al_event_id = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct gw2al_core_vtable {
-    pub hash_name:           unsafe extern "C" fn(name: *mut u16) -> u64,
+    pub hash_name: unsafe extern "C" fn(name: *mut u16) -> u64,
     pub unregister_function: unsafe extern "C" fn(name: gw2al_hashed_name),
-    pub query_function:      unsafe extern "C" fn(name: gw2al_hashed_name) -> *mut c_void,
-    pub unload_addon:        unsafe extern "C" fn(name: gw2al_hashed_name) -> gw2al_api_ret,
-    pub load_addon:          unsafe extern "C" fn(name: *mut u16) -> gw2al_api_ret,
-    pub query_addon:         unsafe extern "C" fn(name: gw2al_hashed_name) -> *mut gw2al_addon_dsc,
-    pub query_event:         unsafe extern "C" fn(name: gw2al_hashed_name) -> gw2al_event_id,
-    pub trigger_event:       unsafe extern "C" fn(id: gw2al_event_id, data: *mut c_void) -> u32,
-    pub client_unload:       unsafe extern "C" fn(),
+    pub query_function: unsafe extern "C" fn(name: gw2al_hashed_name) -> *mut c_void,
+    pub unload_addon: unsafe extern "C" fn(name: gw2al_hashed_name) -> gw2al_api_ret,
+    pub load_addon: unsafe extern "C" fn(name: *mut u16) -> gw2al_api_ret,
+    pub query_addon: unsafe extern "C" fn(name: gw2al_hashed_name) -> *mut gw2al_addon_dsc,
+    pub query_event: unsafe extern "C" fn(name: gw2al_hashed_name) -> gw2al_event_id,
+    pub trigger_event: unsafe extern "C" fn(id: gw2al_event_id, data: *mut c_void) -> u32,
+    pub client_unload: unsafe extern "C" fn(),
     pub fill_vtable:
         unsafe extern "C" fn(nameList: *mut gw2al_hashed_name, vtable: *mut *mut c_void),
     pub unwatch_event: unsafe extern "C" fn(id: gw2al_event_id, subscriber: gw2al_hashed_name),

--- a/src/gw2al_api.rs
+++ b/src/gw2al_api.rs
@@ -20,6 +20,15 @@ pub const GW2AL_CORE_FUNN_CLIENT_UNLOAD: gw2al_hashed_name = 13;
 pub const GW2AL_CORE_FUNN_LOG_TEXT: gw2al_hashed_name = 14;
 pub const GW2AL_CORE_FUNN_D3DCREATE_HOOK: gw2al_hashed_name = 15;
 
+pub const EMPTY_ADDON_DSC: gw2al_addon_dsc = gw2al_addon_dsc {
+    name:        std::ptr::null(),
+    description: std::ptr::null(),
+    majorVer:    0,
+    minorVer:    0,
+    revision:    0,
+    dependList:  std::ptr::null_mut(),
+};
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct gw2al_addon_dsc {

--- a/src/gw2al_api.rs
+++ b/src/gw2al_api.rs
@@ -44,6 +44,7 @@ unsafe impl Send for gw2al_addon_dsc {}
 unsafe impl Sync for gw2al_addon_dsc {}
 
 #[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum gw2al_api_ret {
     OK               = 0,
     FAIL             = 1,
@@ -57,6 +58,7 @@ pub enum gw2al_api_ret {
 }
 
 #[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum gw2al_log_level {
     INFO  = 0,
     ERR   = 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,9 +108,9 @@ impl log::Log for Gw2Al<'_> {
 }
 
 pub struct Gw2AlAddonDsc {
-    pub name:            String,
-    pub description:     String,
-    pub version:         (u8, u8, u32),
+    pub name: String,
+    pub description: String,
+    pub version: (u8, u8, u32),
     pub dependency_list: Vec<Gw2AlAddonDsc>,
 }
 
@@ -137,9 +137,9 @@ impl From<NonNull<gw2al_addon_dsc>> for Gw2AlAddonDsc {
             }
         }
         Self {
-            name:            unsafe { U16CStr::from_ptr_str(raw.name) }.to_string_lossy(),
-            description:     unsafe { U16CStr::from_ptr_str(raw.name) }.to_string_lossy(),
-            version:         (raw.majorVer, raw.minorVer, raw.revision),
+            name: unsafe { U16CStr::from_ptr_str(raw.name) }.to_string_lossy(),
+            description: unsafe { U16CStr::from_ptr_str(raw.name) }.to_string_lossy(),
+            version: (raw.majorVer, raw.minorVer, raw.revision),
             dependency_list: deps,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,11 +99,7 @@ impl log::Log for Gw2Al<'_> {
     }
 
     fn log(&self, record: &Record<'_>) {
-        let from = format!(
-            "{}:{}",
-            record.file().unwrap_or_default(),
-            record.line().unwrap_or_default()
-        );
+        let from = record.target().split("::").next().unwrap();
         let body = record.args().to_string();
         self.log_text(record.level().into(), &from, &body);
     }


### PR DESCRIPTION
## Fixes
- The order of vtable functions is now correct and `log_text_sync` has been added (based on [gw2al_api.h](https://github.com/gw2-addon-loader/loader-core/blob/master/include/gw2al_api.h#L65-L104))

## Smaller improvements
- Derive `Debug`, `Copy`, `Clone`, `PartialEq` and `Eq` for enums
- Add zero initialized addon description used for filling `dependList`
- Log name of crate instead of path
  - Removes a lot of clutter from log file in release mode
  - Possible improvement: File path and line number could be added in debug mode